### PR TITLE
fix: remove mention of the site dropdown

### DIFF
--- a/supertab-experiences/experiences.mdx
+++ b/supertab-experiences/experiences.mdx
@@ -32,7 +32,7 @@ We automatically create the first Paywall for each new site using default time p
     If you intend to use the automatically generated Paywall, click the **Edit** button next to it.
   </Step>
   <Step title="Paywall Setup">
-    From the Site dropdown, choose the Site where the Paywall should appear. Select **Paywall** as the Experience type.
+    Select **Paywall** as the Experience type.
 
     Paywall Redirect URL determines where we will redirect customers if they see the Paywall and close it. We automatically set it to your site URL but it can redirect anywhere (e.g. to a dedicated page).
 


### PR DESCRIPTION
## Context
Some time ago we have restructured the entire Business Portal architecture. The site is now selected first, and all related content and configurations are created automatically for that site. As a result, the site dropdown has been removed from the Experience Editor, and the documentation must be updated accordingly.