### PR TITLE
feat: add docs for new public function createPurchase

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -78,6 +78,7 @@
                   "supertab-js/reference/overview",
                   "supertab-js/reference/create-paygate",
                   "supertab-js/reference/create-paywall",
+                  "supertab-js/reference/create-purchase",
                   "supertab-js/reference/auth",
                   "supertab-js/reference/api",
                   "supertab-js/reference/checkout",

--- a/snippets/supertab-js/purchase-state-summary-types.mdx
+++ b/snippets/supertab-js/purchase-state-summary-types.mdx
@@ -1,0 +1,77 @@
+```typescript PurchaseStateSummary type definition
+interface PurchaseStateSummary {
+    priorEntitlement: EntitlementStatus[] | null;
+    authStatus: AuthStatus;
+    purchase: Purchase | null;
+    purchasedOffering: Offering | null;
+    tab: Tab | null;
+    paymentResult: boolean;
+}
+
+type EntitlementStatus = {
+    contentKey: string;
+    hasEntitlement: boolean;
+    expires: string;
+    recursAt: Date | null;
+}
+
+enum AuthStatus {
+    MISSING = "missing",
+    EXPIRED = "expired",
+    VALID = "valid"
+}
+
+type Purchase = {
+    id: string;
+    offeringId?: string | null;
+    purchasedAt: string | null;
+    completedAt: string | null;
+    description: string;
+    price: Price;
+    status: PurchaseStatus;
+    metadata: Metadata;
+    entitlementStatus: EntitlementStatus | null;
+}
+
+type Metadata = Record<string, string | number | boolean | null>;
+
+enum PurchaseStatus {
+    PENDING = "pending",
+    COMPLETED = "completed",
+    ABANDONED = "abandoned"
+}
+
+type Price = {
+    amount: number;
+    currency: Currency;
+}
+
+type Currency = {
+    code: string;
+    symbol: string;
+    name: string;
+    baseUnit: number;
+}
+
+type Offering = {
+    id: string;
+    description: string;
+    entitlementDetails: EntitlementDetails;
+    price: Price;
+    isPayNow: boolean;
+}
+
+type EntitlementDetails = {
+    contentKey: string;
+    duration: string;
+    isRecurring: boolean;
+}
+
+type Tab = {
+    testMode: boolean;
+    currency: Currency;
+    total: Price;
+    limit: Price;
+    purchases: Purchase[];
+}
+```

--- a/supertab-js/reference/create-purchase.mdx
+++ b/supertab-js/reference/create-purchase.mdx
@@ -1,0 +1,48 @@
+---
+title: "Supertab.createPurchase"
+description: "API reference for `Supertab.createPurchase`"
+sidebarTitle: "Supertab.createPurchase"
+---
+
+import PurchaseStateSummaryTypes from "/snippets/supertab-js/purchase-state-summary-types.mdx";
+
+## Parameters
+
+| Key                | Type     | Required | Description                                                         |
+| :----------------- | :------- | :------- | :------------------------------------------------------------------ |
+| `offeringId`       | `string` | Yes      | ID of the offering created in the Business Portal                   |
+| `purchaseMetadata` | `object` | No       | Key-value pairs of custom information associated with the purchase. |
+
+## Returns
+
+A promise that resolves to the initial state of the purchase and methods for showing it to users. Type of the response is [`CreatePurchaseResult`](#createpurchaseresult).
+
+| Field           | Type                   | Description                                                                                                                                     |
+| :-------------- | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `startPurchase` | `PurchaseStateSummary` | The state of the purchase immediately after config is loaded, can be used to check if the user is logged in or has a prior entitlement already. |
+| `destroy`       | `() => void`           | Clean up and remove all Supertab elements from the DOM.                                                                                         |
+
+## Example
+
+```javascript
+const supertabClient = new Supertab({ clientId: "client.your_client" });
+
+const { startPurchase, destroy } = await supertabClient.createPurchase({
+  offeringId: "offering.your-offering-id",
+});
+```
+
+## Types
+
+### `PurchaseStateSummary`
+
+<PurchaseStateSummaryTypes />
+
+### `CreatePurchaseResult`
+
+```typescript CreatePurchaseResult type definition
+interface CreatePurchaseResult {
+  startPurchase: () => Promise<PurchaseStateSummary>;
+  destroy: () => void;
+}
+```


### PR DESCRIPTION
Depends on merging supertab-js PR: https://github.com/laterpay/supertab-js/pull/1178

This PR adds a documentation for a new public function `createPurchase` in supertab-js :

<img width="1500" height="810" alt="Monosnap Supertab createPurchase - Supertab docs 2025-09-23 13-55-43" src="https://github.com/user-attachments/assets/0fc11fea-b53e-4784-afa3-d018fb2af22a" />
