### PR TITLE
chore: improve the createPurchase function documentation

### DIFF
--- a/supertab-js/reference/create-purchase.mdx
+++ b/supertab-js/reference/create-purchase.mdx
@@ -17,10 +17,10 @@ import PurchaseStateSummaryTypes from "/snippets/supertab-js/purchase-state-summ
 
 A promise that resolves to the function to start the purchase and a destroy method to control the purchase widget programmatically. Type of the response is [`CreatePurchaseResult`](#createpurchaseresult).
 
-| Field           | Type                   | Description                                             |
-| :-------------- | :--------------------- | :------------------------------------------------------ |
-| `startPurchase` | `PurchaseStateSummary` | The startPurchase function to start the purchase flow.  |
-| `destroy`       | `() => void`           | Clean up and remove all Supertab elements from the DOM. |
+| Field           | Type                                  | Description                                             |
+| :-------------- | :------------------------------------ | :------------------------------------------------------ |
+| `startPurchase` | `() => Promise<PurchaseStateSummary>` | The startPurchase function to start the purchase flow.  |
+| `destroy`       | `() => void`                          | Clean up and remove all Supertab elements from the DOM. |
 
 ## Example
 
@@ -30,6 +30,17 @@ const supertabClient = new Supertab({ clientId: "client.your_client" });
 const { startPurchase, destroy } = await supertabClient.createPurchase({
   offeringId: "offering.your-offering-id",
 });
+
+const result = await purchaseController.startPurchase();
+
+// Then you can handle the result
+if (result.purchase?.status === "completed") {
+  console.log("Purchase completed successfully:", result.purchase);
+} else if (result.purchase?.status === "abandoned") {
+  console.log("Purchase cancelled:", result.purchase);
+} else if (result.priorEntitlement) {
+  console.log("User already has entitlement:", result.priorEntitlement);
+}
 ```
 
 ## Types

--- a/supertab-js/reference/create-purchase.mdx
+++ b/supertab-js/reference/create-purchase.mdx
@@ -15,12 +15,12 @@ import PurchaseStateSummaryTypes from "/snippets/supertab-js/purchase-state-summ
 
 ## Returns
 
-A promise that resolves to the result of the purchase and a destroy method to control the purchase widget programmatically. Type of the response is [`CreatePurchaseResult`](#createpurchaseresult).
+A promise that resolves to the function to start the purchase and a destroy method to control the purchase widget programmatically. Type of the response is [`CreatePurchaseResult`](#createpurchaseresult).
 
-| Field           | Type                   | Description                                                                       |
-| :-------------- | :--------------------- | :-------------------------------------------------------------------------------- |
-| `startPurchase` | `PurchaseStateSummary` | The result of the startPurchase - can be used to check the state of the purchase. |
-| `destroy`       | `() => void`           | Clean up and remove all Supertab elements from the DOM.                           |
+| Field           | Type                   | Description                                             |
+| :-------------- | :--------------------- | :------------------------------------------------------ |
+| `startPurchase` | `PurchaseStateSummary` | The startPurchase function to start the purchase flow.  |
+| `destroy`       | `() => void`           | Clean up and remove all Supertab elements from the DOM. |
 
 ## Example
 

--- a/supertab-js/reference/create-purchase.mdx
+++ b/supertab-js/reference/create-purchase.mdx
@@ -15,12 +15,12 @@ import PurchaseStateSummaryTypes from "/snippets/supertab-js/purchase-state-summ
 
 ## Returns
 
-A promise that resolves to the initial state of the purchase and methods for showing it to users. Type of the response is [`CreatePurchaseResult`](#createpurchaseresult).
+A promise that resolves to the result of the purchase and a destroy method to control the purchase widget programmatically. Type of the response is [`CreatePurchaseResult`](#createpurchaseresult).
 
-| Field           | Type                   | Description                                                                                                                                     |
-| :-------------- | :--------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `startPurchase` | `PurchaseStateSummary` | The state of the purchase immediately after config is loaded, can be used to check if the user is logged in or has a prior entitlement already. |
-| `destroy`       | `() => void`           | Clean up and remove all Supertab elements from the DOM.                                                                                         |
+| Field           | Type                   | Description                                                                       |
+| :-------------- | :--------------------- | :-------------------------------------------------------------------------------- |
+| `startPurchase` | `PurchaseStateSummary` | The result of the startPurchase - can be used to check the state of the purchase. |
+| `destroy`       | `() => void`           | Clean up and remove all Supertab elements from the DOM.                           |
 
 ## Example
 

--- a/supertab-js/reference/create-purchase.mdx
+++ b/supertab-js/reference/create-purchase.mdx
@@ -31,7 +31,7 @@ const { startPurchase, destroy } = await supertabClient.createPurchase({
   offeringId: "offering.your-offering-id",
 });
 
-const result = await purchaseController.startPurchase();
+const result = await startPurchase();
 
 // Then you can handle the result
 if (result.purchase?.status === "completed") {


### PR DESCRIPTION
This PR improves the documentation for `createPurchase` function - make it clear what are the types of properties that `createPurchase` returns:

<img width="1195" height="731" alt="Monosnap Supertab createPurchase - Supertab docs 🔊 2025-09-24 14-18-46" src="https://github.com/user-attachments/assets/f7d22caf-7aa1-4689-995c-1e6c61cfc32d" />

Also, adds an example how to start the purchase and what is the expected result:
<img width="860" height="596" alt="Monosnap Supertab createPurchase - Supertab docs 2025-09-24 14-30-52" src="https://github.com/user-attachments/assets/1ad40af5-9dfc-46ba-8b5e-51b9df503c4b" />

