### PR TITLE
fix: fix products link

### DIFF
--- a/supertab-experiences/introduction.mdx
+++ b/supertab-experiences/introduction.mdx
@@ -8,7 +8,7 @@ and access entitlement to your premium content.
 
 <Steps>
   <Step title="Set up your inventory">
-    Tell us about your <a href="./sites">Sites</a> and the <a href="./products">Products</a> you wish to sell.
+    Tell us about your <a href="./sites">Sites</a> and the <a href="./products-offerings-pricing">Products</a> you wish to sell.
   </Step>
 
   <Step title="Configure your experiences">


### PR DESCRIPTION
## Jira ticket
[CL-2252](https://laterpay.atlassian.net/browse/CL-2252)

## Context
This PR fixes the "Products" link and makes it to point to https://docs.supertab.co/supertab-experiences/products-offerings-pricing

[CL-2252]: https://laterpay.atlassian.net/browse/CL-2252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ