### PR TITLE
feat: add missing docs for createPurchaseButton in API reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -78,6 +78,7 @@
                   "supertab-js/reference/overview",
                   "supertab-js/reference/create-paygate",
                   "supertab-js/reference/create-paywall",
+                  "supertab-js/reference/purchase-button",
                   "supertab-js/reference/create-purchase",
                   "supertab-js/reference/auth",
                   "supertab-js/reference/api",

--- a/supertab-js/reference/purchase-button.mdx
+++ b/supertab-js/reference/purchase-button.mdx
@@ -1,0 +1,92 @@
+---
+title: "Supertab.createPurchaseButton"
+description: "Invoking Purchase Button experience in Supertab.js"
+---
+
+import ExperienceStateSummary from "/snippets/supertab-js/experience-state-summary.mdx";
+
+## `createPurchaseButton`
+
+```html
+<div id="supertab-button-container"></div>
+```
+
+```javascript
+const supertabClient = new Supertab({ clientId: "test_client.abc" });
+
+const { destroy, initialState } = await supertabClient.createPurchaseButton({
+  containerElement: document.getElementById("supertab-button-container"),
+  experienceId: "experience.abc",
+});
+```
+
+### Parameters
+
+`createPurchaseButton` accepts the object with following properties:
+
+<ParamField path="containerElement" type="Element" required>
+  Container element to render purchase button in. Elements are appended to the
+  container, so original contents are not replaced.
+</ParamField>
+
+<ParamField path="experienceId" type="string" required>
+  ID of the purchase button experience created in Business Portal.
+</ParamField>
+
+<ParamField path="purchaseMetadata" type="object">
+  Key-value pairs of custom information associated with the purchase.
+</ParamField>
+
+<ParamField path="onDone" type="function">
+  Callback function called when user leaves the purchase flow either as a result of successful purchase or cancellation.
+
+Returns a promise which resolves with the purchase button summary. See [Purchase button summary](#purchase-button-summary) for more details.
+
+</ParamField>
+
+### Return value
+
+A promise which resolves with an object with following properties:
+
+<ResponseField name="destroy" type="function">
+  Destroy Supertab button instance. This removes all nodes related to Supertab
+  button from DOM.
+</ResponseField>
+
+<ResponseField name="initialState" type="object">
+  Initial state of the purchase button. See [Purchase button
+  summary](#purchase-button-summary) for more details.
+</ResponseField>
+
+## Purchase button summary
+
+Both the returned `initialState` object and the object passed as an argument to the `onDone` callback contain the following properties:
+
+<ExperienceStateSummary />
+
+## Example
+
+```javascript Example
+const { destroy, initialState } = await supertabClient.createPurchaseButton({
+  containerElement: document.getElementById("supertab-button-container"),
+  experienceId: "experience.abc",
+  onDone: ({ priorEntitlement, purchase }) => {
+    if (priorEntitlement) {
+      // User has prior entitlement to the content.
+      return;
+    }
+
+    if (purchase) {
+      if (purchase.status === "completed") {
+        // Purchase was completed successfully.
+      } else {
+        // Purchase was not completed. User may have
+        // canceled the payment dialog if purchase
+        // required payment.
+      }
+    } else {
+      // User has canceled the flow and did not
+      // attempt to purchase the offering.
+    }
+  }
+```


### PR DESCRIPTION
This PR adds missing docs for `createPurchaseButton` supertab-js function.

<img width="1510" height="723" alt="Monosnap Supertab createPurchaseButton - Supertab docs 2025-09-25 16-19-12" src="https://github.com/user-attachments/assets/293fa03a-26b4-4f63-9282-494ba55ae30b" />
