### PR TITLE
Add context7.json for Context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://context7.com/websites/supertab_co",
+  "public_key": "pk_7jbHb53Gih9gbcbDRVsre"
+}
+


### PR DESCRIPTION
## Summary
- add a root-level context7.json file to the docs site
- expose the Context7 website URL and public key at /context7.json

## Testing
- validated the JSON locally with jq .